### PR TITLE
refactor: fix compat with other non-body-boxed middleware

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix-web = "4.0.0-beta.21"
+actix-web = { version = "4.0.0-beta.21", default-features = false }
 chrono = { version = "0.4.19", features = ["serde"] }
-futures-util = "0.3.19"
+futures-util = { version = "0.3.19", default-features = false, features = ["std"] }
 log = "0.4.14"
 jsonwebtoken = "7.2.0"
 serde = { version = "1.0.134", features = ["derive"] }
@@ -25,7 +25,6 @@ uuid = { version = "0.8.2", features = ["serde"] }
 paperclip = { git = "https://github.com/sfisol/paperclip", version = "0.6.1", rev = "99db92949e95287fbeb8f3ea844291f1810cccee", features = ["actix"], optional = true } # we depend on a fork until paperclip supports actix-web 4; see https://github.com/wafflespeanut/paperclip/pull/314
 
 [dev-dependencies]
-actix-rt = "2.6.0"
 env_logger = "0.9.0"
 uuid = { version = "0.8.2", features = ["serde", "v4"] }
 

--- a/examples/paperclip.rs
+++ b/examples/paperclip.rs
@@ -6,7 +6,10 @@
 // This example needs to be run with the paperclip_compat feature
 // For example: cargo run --example paperclip --features paperclip_compat
 
-use actix_web::{middleware, App, HttpServer};
+use actix_web::{
+    middleware::{self, Compat},
+    App, HttpServer,
+};
 use actix_web_middleware_keycloak_auth::{
     AlwaysReturnPolicy, DecodingKey, KeycloakAuth, Role, StandardKeycloakClaims,
 };
@@ -73,7 +76,8 @@ async fn main() -> std::io::Result<()> {
             .wrap_api()
             .service(
                 web::scope("/private")
-                    .wrap(keycloak_auth)
+                    // Compat only needed because of paperclip version of `wrap`
+                    .wrap(Compat::new(keycloak_auth))
                     .route("", web::get().to(private)),
             )
             .service(web::resource("/").to(hello_world))


### PR DESCRIPTION
Will prevent certain orders of `.wrap()` calls from failing to compile.

Unfortunately paperclip doesn't yet support non-boxed body types in `Scope::wrap` so a workaround is used in that example.