### PR TITLE
Chore bump paperclip to 0.9.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,21 +11,36 @@ categories = ["authentication", "web-programming::http-server"]
 keywords = ["actix-web", "middleware", "authentication", "jwt", "keycloak"]
 license = "MIT"
 
+[[example]]
+name = "custom_claims"
+path = "examples/custom_claims.rs"
+required-features = ["paperclip_compat"]
+
+[[example]]
+name = "paperclip"
+path = "examples/paperclip.rs"
+required-features = ["paperclip_compat"]
+
+[[example]]
+name = "simple"
+path = "examples/simple.rs"
+required-features = ["paperclip_compat"]
+
 [dependencies]
-actix-web = { version = "4.4.0", default-features = false }
-chrono = { version = "0.4.31", features = ["serde"] }
-futures-util = { version = "0.3.29", default-features = false, features = ["std"] }
-log = "0.4.20"
-jsonwebtoken = "9.2.0"
-serde = { version = "1.0.193", features = ["derive"] }
+actix-web = { version = "4.9.0", default-features = false }
+chrono = { version = "0.4.38", features = ["serde"] }
+futures-util = { version = "0.3.30", default-features = false, features = ["std"] }
+log = "0.4.22"
+jsonwebtoken = "9.3.0"
+serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.108"
-uuid = { version = "1.6.1", features = ["serde"] }
-paperclip = { version = "0.8.2", default-features = false, features = ["actix4"], optional = true }
+uuid = { version = "1.10.0", features = ["serde"] }
+paperclip = { version = "0.9.1", default-features = false, features = ["actix4", "paperclip-actix"], optional = true }
 
 [dev-dependencies]
 actix-web = { version = "4.4.0", default-features = false, features = ["macros"] }
-env_logger = "0.10.1"
-uuid = { version = "1.6.1", features = ["serde", "v4"] }
+env_logger = "0.11.5"
+uuid = { version = "1.10.0", features = ["serde", "v4"] }
 
 [features]
 default = []


### PR DESCRIPTION
# Update Dependencies

This PR updates several dependencies to their latest versions.

## Background

[actix-web-middleware-keycloak-auth](https://github.com/dsferruzza/actix-web-middleware-keycloak-auth) does not work with paperclip 0.9.1.

## Changes

### Dependency Updates

- Upgraded `actix-web` from 4.4.0 to 4.9.0
- Upgraded `chrono` from 0.4.31 to 0.4.38
- Upgraded `futures-util` from 0.3.29 to 0.3.30
- Upgraded `log` from 0.4.20 to 0.4.22
- Upgraded `jsonwebtoken` from 9.2.0 to 9.3.0
- Upgraded `serde` from 1.0.193 to 1.0.210
- Upgraded `uuid` from 1.6.1 to 1.10.0
- Upgraded `paperclip` from 0.8.2 to 0.9.1
- Upgraded `env_logger` (dev dependency) from 0.10.1 to 0.11.5

### Paperclip Configuration

Updated the `paperclip` dependency configuration to include the `paperclip-actix` feature.
